### PR TITLE
add mongo-ingest module

### DIFF
--- a/gfftoolbox/__main__.py
+++ b/gfftoolbox/__main__.py
@@ -33,6 +33,7 @@ commands:
     filter                                                  It lets you filter your GFF based on one or multiple patterns
     convert                                                 Converts a GFF file into another formats
     plot                                                    Useful command to plot genomic regions from a GFF file
+    mongo-ingest                                            Useful command to plot genomic regions from a GFF file
 
 Use: `gff-toolbox <commmand> -h` to get more help and see examples.
 """
@@ -52,6 +53,7 @@ from .filter import *
 from .version import *
 from .convert import *
 from .plot import *
+from .ingest import *
 
 ## Defining main
 def main():
@@ -63,10 +65,10 @@ def main():
     ### GFF overview command ###
     ############################
     if arguments['<command>'] == 'overview':
-
+        
         # Parse docopt
         args_overview = docopt(usage_overview, version=__version__, help=False)
-
+        
         if args_overview['overview'] and args_overview['--help']:
             print(usage_overview.strip())
 
@@ -119,6 +121,27 @@ def main():
 
         else:
             print(usage_convert.strip())
+
+    ###########################
+    ### GFF ingest command ###
+    ###########################
+    elif arguments['<command>'] == 'mongo-ingest':
+
+        # Parse docopt
+        args_ingest = docopt(usage_ingest, version=__version__, help=False)
+
+        if args_ingest['mongo-ingest'] and args_ingest['--help']:
+            print(usage_ingest.strip())
+
+        ## Run it
+        elif args_ingest['mongo-ingest'] and args_ingest['--input'] and args_ingest['--db_name'] and not args_ingest['--help']:
+            
+            ingestAttributes(filename=args_ingest['--input'], feature_type=args_ingest['--gff_feature'],
+             db_name=args_ingest['--db_name'], collection_name=args_ingest['--genome_name'],
+              mongo_path=args_ingest['--mongo_path'], has_header=True)
+
+        else:
+            print(usage_ingest.strip())
 
     ########################
     ### GFF plot command ###

--- a/gfftoolbox/__main__.py
+++ b/gfftoolbox/__main__.py
@@ -33,7 +33,7 @@ commands:
     filter                                                  It lets you filter your GFF based on one or multiple patterns
     convert                                                 Converts a GFF file into another formats
     plot                                                    Useful command to plot genomic regions from a GFF file
-    mongo-ingest                                            Useful command to plot genomic regions from a GFF file
+    mongo-ingest                                            Useful to include new or update annotations in existing GFF mongo databases
 
 Use: `gff-toolbox <commmand> -h` to get more help and see examples.
 """

--- a/gfftoolbox/convert.py
+++ b/gfftoolbox/convert.py
@@ -103,7 +103,17 @@ def att_to_dict(attributes):
     for atts in attributes.split(";"):
         try:
             key, value = atts.split("=")
-            final[key] = value.strip()
+            if key == "Dbxref" or key=="Ontology_terms":
+                try:
+                    values = [{"DBTAG": x.split(":")[0], "ID": x.split(":")[1]} for x in value.strip().split(",")]
+                    final[key] = values
+                except ValueError:
+                    print(f"The field Dbxref or Ontology_terms are not in format specified by GFF standards. Problem in {atts}.")
+            else:
+                if len(value.strip().split(",")) == 1:
+                    final[key] = value.strip().split(",")[0]
+                else:
+                    final[key] = value.strip().split(",")
         except ValueError:
             print(f"Can't split attributes. Problem in {atts}")
             break

--- a/gfftoolbox/ingest.py
+++ b/gfftoolbox/ingest.py
@@ -11,7 +11,7 @@ usage:
     gff-toolbox mongo-ingest -h | --help
 
 options:
-    -h, --help                                              Show this screen
+    -h, --help                                              Show this screen.
     -i, --input=<tsv>                                       Annotation file in TSV (tab-separated values) format describing, for each line, the gff feature
                                                             (default: gene, can be changed in parameter --gff_feature) id and
                                                             corresponding annotations that should be included in mongodb database.

--- a/gfftoolbox/ingest.py
+++ b/gfftoolbox/ingest.py
@@ -4,10 +4,11 @@ gff-toolbox:
 
             Mongo-ingest
 
-This command uses several python libraries to provide an easy way to convert your GFF data
+This command add annotations into an already created GFF mongo database.
 
 usage:
-    gff-toolbox mongo-ingest [ -h|--help ] [ --input <tsv> ] [--gff_feature gene --db_name <db_name> --genome_name <genome_name> --mongo_path <mongo_path> ]
+    gff-toolbox mongo-ingest --input <tsv> [--gff_feature gene --db_name <db_name> --genome_name <genome_name> --mongo_path <mongo_path> ]
+    gff-toolbox mongo-ingest -h | --help
 
 options:
     -h, --help                                              Show this screen
@@ -26,13 +27,16 @@ options:
 
 example:
 
-    ## Converting a GFF to a mongoDB and updating annotation for genes listed in gene.functions.txt file
-    ## This will be added to a mongo db called <db_name> in a collection named <genome_name>
-    ## DBs are writen in the localhost 27027 mongo db connection of mongo shell
+    ## Create a mongo database from a GFF, if it doesnt exist yet
+    ## This will create the GFF mongodb collection named <genome_name> in mongodb <db_name>
+    ## DBs are writen in the localhost 27027 mongo db connection of mongo shell    
 
-$ gff-toolbox convert --format mongodb -i Kp_ref.gff -n Kp
+    $ gff-toolbox convert --format mongodb -i Kp_ref.gff --genome_name Kp
 
-$ gff-toolbox mongo-ingest -i gene.functions.txt -n Kp
+    ## Next, include annotations written in gene.functions.txt file to corresponding
+    ## gene features in existing GFF mongo collection Kp
+
+    $ gff-toolbox mongo-ingest -i gene.functions.tsv -n Kp
 
 """
 
@@ -51,8 +55,6 @@ import json
 import pymongo
 from pymongo import MongoClient
 from pymongo import collection
-from BCBio import GFF
-from Bio import SeqIO
 from io import StringIO
 import binascii
 import pathlib

--- a/gfftoolbox/ingest.py
+++ b/gfftoolbox/ingest.py
@@ -1,0 +1,217 @@
+## Def convert help
+usage_ingest="""
+gff-toolbox:
+
+            Mongo-ingest
+
+This command uses several python libraries to provide an easy way to convert your GFF data
+
+usage:
+    gff-toolbox mongo-ingest [ -h|--help ] [ --input <tsv> ] [--gff_feature gene --db_name <db_name> --genome_name <genome_name> --mongo_path <mongo_path> ]
+
+options:
+    -h, --help                                              Show this screen
+    -i, --input=<tsv>                                       Annotation file in TSV (tab-separated values) format describing, for each line, the gff feature
+                                                            (default: gene, can be changed in parameter --gff_feature) id and
+                                                            corresponding annotations that should be included in mongodb database.
+                                                            The annotation file must contain four columns (#locusName\tId\tIdType\tdescription). [Default: stdin].
+    -l, --gff_feature=<feature_type>                        Which GFF feature type must be annotated. [Default: gene].
+    -d, --db_name=<db_name>                                 Name of existing mongodb database to update with anotations.
+                                                            If database doesnt exist, create it using gff-toolbox convert module [Default: annotation_db].
+    -n, --genome_name=<genome_name>                         When loading the mongodb this will be used as collection name. [Default: Genome].
+    -p, --mongo_path=<mongo_path>                           Where to load your mongoDB? [Default: ./mongodb].
+                                                            If you insert a path that already have a mongoDB in it will include (append)
+                                                            the GFF as new collection (<genome_name>) in a new or existing DB (<db_name>).
+
+
+example:
+
+    ## Converting a GFF to a mongoDB and updating annotation for genes listed in gene.functions.txt file
+    ## This will be added to a mongo db called <db_name> in a collection named <genome_name>
+    ## DBs are writen in the localhost 27027 mongo db connection of mongo shell
+
+$ gff-toolbox convert --format mongodb -i Kp_ref.gff -n Kp
+
+$ gff-toolbox mongo-ingest -i gene.functions.txt -n Kp
+
+"""
+
+##################################
+### Loading Necessary Packages ###
+##################################
+import sys
+import os
+import re
+import time
+import tempfile
+from collections import namedtuple
+import gzip
+import urllib.request, urllib.parse, urllib.error
+import json
+import pymongo
+from pymongo import MongoClient
+from pymongo import collection
+from BCBio import GFF
+from Bio import SeqIO
+from io import StringIO
+import binascii
+import pathlib
+
+######################################
+### GFF columns names -- immutable ###
+######################################
+gff_cols = ["recid", "source", "type", "start", "end", "score", "strand", "phase", "attributes"]
+
+#############################################
+### Parse attribute columns as dictionary ###
+#############################################
+def att_to_dict(attributes):
+
+    final = {} # Initialize dictionary
+    for atts in attributes.split(";"):
+        try:
+            key, value = atts.split("=")
+            final[key] = value.strip()
+        except ValueError:
+            print(f"Can't split attributes. Problem in {atts}")
+            break
+
+    return final
+
+########################
+### Useful functions ###
+########################
+
+# Check for stdin
+def stdin_checker(input):
+    # Checking for stdin
+    if input == "stdin":
+        tmp = tempfile.NamedTemporaryFile(mode = "w+t", delete = False) # Create tmp file to work as input
+        temp_file = open(tmp.name, 'w+t')
+        for line in sys.stdin:
+            temp_file.writelines(f"{line}")
+
+        temp_file.seek(0)
+        input = tmp.name
+
+    else:
+        pass
+
+    return input
+
+# Print fasta format
+def fasta_printer(id, seq):
+    print(f">{id}\n{seq}")
+
+# Get feature identifier
+def tag_getter(record, seq):
+    if record.id != "":
+        tag = record.id
+    else:
+        tag = f"{record.type}_{seq.id}:{record.location.start}-{record.location.end}"
+
+    return tag
+
+# Open gzipped files
+def gzip_opener(input, mode_in):
+    if  binascii.hexlify(open(input, 'rb').read(2)) == b"1f8b" or input.endswith(".gz"):
+        return gzip.open(input, mode=mode_in)
+    else:
+        return open(input, mode=mode_in)
+
+# Remove nest from GFF
+def _flatten_features(rec):
+        """Make sub_features in an input rec flat for output.
+
+        GenBank does not handle nested features, so we want to make
+        everything top level.
+        """
+        out = []
+        for f in rec.features:
+            cur = [f]
+            while len(cur) > 0:
+                nextf = []
+                for curf in cur:
+                    out.append(curf)
+                    if len(curf.sub_features) > 0:
+                        nextf.extend(curf.sub_features)
+                cur = nextf
+        rec.features = out
+        return rec
+
+
+def ingestAttributes(filename, db_name, collection_name, mongo_path, feature_type, has_header):
+
+    # Start mongo
+    current = pathlib.Path().absolute()
+    # os.system(f"mkdir -p {mongo_path} {mongo_path}/{db_name}")
+    os.system(f"cd {mongo_path} && mongod --dbpath {db_name} --logpath mongo_{collection_name}.log &")
+
+    # Create connection
+    client = MongoClient()
+
+    # Create Database
+    db = client[db_name]
+
+    # Create Collection
+    collection = db[collection_name]
+
+    # Create a compound index to further accelerate the update of collection entries
+    # requires pymongo
+    collection.create_index( [ ("type", 1),  ("attributes.ID", 1) ])
+
+
+    # Open
+    contents = gzip_opener(stdin_checker(filename), "rt")
+
+
+
+    for idxline, line in enumerate(contents):
+        
+        if idxline == 0 and has_header: continue
+        
+        try:
+                gene_name, iddb, idType, description = line.strip("\n").split("\t")
+        except ValueError:
+                print("Error: Could not unpack the values in line number {}: {}.\n \
+                The file with the set of attributes to ingest into GFF must have 4 \
+                 columns and be tab-delimited.".format(str(idxline), line.strip("\n").split("\t")))
+        
+        if (idxline % 1000) == 0:
+            print("Update Col 9 N=", str(idxline))
+        if idType != "GO":
+            if len(description) == 0:
+                obj = {"DBTAG": idType, "ID": iddb}
+            else:
+                obj = {"DBTAG": idType, "ID": iddb, "Description": description}
+            
+            collection.update_one(
+                # query                 
+                {'type': 'gene', 'attributes.ID': gene_name},
+                # update
+                {"$addToSet": {"attributes.Dbxref": obj}}
+                # update options (Optional)
+            )
+        else:
+            if len(description) == 0:
+                obj = {"DBTAG": "GO", "ID": iddb}
+            else:
+                obj = {"DBTAG": "GO", "ID": iddb, "Description": description}
+            collection.update_one(
+                {'type': 'gene', 'attributes.ID': gene_name},
+                {"$addToSet": {"attributes.Ontology_term": obj}}
+            )
+
+    # Close
+    client.close()
+    os.system(f"cd {current}")
+
+
+
+################
+### Def main ###
+################
+# (filename, db_name, collection_name, mongo_path, feature_type, has_header)
+def ingest(filename, feature_type, db_name, genome_name, mongo_path):
+
+    ingestAttributes(filename=filename, db_name=db_name, collection_name=genome_name, mongo_path=mongo_path, feature_type=feature_type, has_header=True)

--- a/test/gene.functions.tsv
+++ b/test/gene.functions.tsv
@@ -1,4 +1,4 @@
-##ID	Id	IdType	description
+FeatureId	AnnotId	IdType	Description
 gene-KPHS_00170	PTHR30520:SF0	PANTHER	TRANSPORTER-RELATED
 gene-KPHS_00170	GO:0006810	GO	transport
 gene-KPHS_00170	3.4.16.2	EC	Lysosomal Pro-Xaa carboxypeptidase

--- a/test/gene.functions.tsv
+++ b/test/gene.functions.tsv
@@ -1,0 +1,7 @@
+##ID	Id	IdType	description
+gene-KPHS_00170	PTHR30520:SF0	PANTHER	TRANSPORTER-RELATED
+gene-KPHS_00170	GO:0006810	GO	transport
+gene-KPHS_00170	3.4.16.2	EC	Lysosomal Pro-Xaa carboxypeptidase
+gene-KPHS_00170	GO:0005215	GO	transporter activity
+gene-KPHS_02590	GO:0003735	GO	structural constituent of ribosome
+gene-KPHS_02590	PTHR36029	PANTHER	


### PR DESCRIPTION
Closes #4 

When this PR is finished, the module gff-toolbox mongo-ingest will be functional. It still left to implement in another PR the other mentioned function able to convert back mongodb database to GFF or other format. Update the docs/Wiki/README is not supplied by this PR and must be done also in another PR.